### PR TITLE
Image spacing to make MkDocs/GitHub happy

### DIFF
--- a/metro-extracts/walkthrough.md
+++ b/metro-extracts/walkthrough.md
@@ -15,7 +15,7 @@ Originally created by Mike Migurski, Mapzen has taken over hosting and maintenan
 1. Open a web browser to the Metro Extracts download page at https://mapzen.com/data/metro-extracts/. The page has a map showing the available downloads, as well as a filter box and an alphabetical list of city names below it.
 2. Below the map, in the Filter box, type `lisbon`. You can also zoom in on the map to see the area covered and click a box to choose the city.
 
-  ![Filter the list of extracts](./images/filter_extracts.png)
+    ![Filter the list of extracts](./images/filter_extracts.png)
 
 3. The matching result appears in the list. If you do not see the city you want, choose another one from the list. (Note that you can submit a GitHub request to add a city to the list of extracts, but more on that later).
 
@@ -25,7 +25,7 @@ The names and contents of the shapefiles and GeoJSON files are based on the proc
 
 You will download one of each of these export types so you can explore the file structure, using both shapefiles and GeoJSONs.
 
-  ![Available files for Lisbon, Portugal](./images/lisbon_download_formats.png)
+![Available files for Lisbon, Portugal](./images/lisbon_download_formats.png)
 
 1. Click OSM2PGSQL SHP to download the shapefile.
 2. Click IMPOSM GEOJSON to download the GeoJSON.
@@ -44,7 +44,7 @@ Now that the files are downloaded, you will load them into QGIS.
 3. Notice that the folder contains three shapefiles, named by the geometry type: point, line, and polygon.
 4. Drag the line layer onto the map. Because the extracts are based on a rectangular bounding box, the layer's extent will extend beyond the true administrative boundaries of a city.
 
-  ![osm2pgsql layers added to a map](./images/osm_line_default.png)
+    ![osm2pgsql layers added to a map](./images/osm_line_default.png)
 
 ###Add a basemap to your map
 
@@ -59,7 +59,7 @@ With the lines alone, it is hard to tell much about the area. You can add a base
 ####Choose a basemap
 1. Click the Web menu, point to OpenLayers Plugin, point to OSM/Stamen, and click Stamen Toner/OSM. This adds a black-and-white basemap of OpenStreetMap data provided by Stamen.
 
-  ![Add a basemap](./images/add_basemap.png)
+    ![Add a basemap](./images/add_basemap.png)
 
 2. If the basemap obscures your line layer, drag the basemap to the bottom of the layer list.
 
@@ -74,7 +74,7 @@ In OSM, a feature is identified through a [tag](http://wiki.openstreetmap.org/wi
 1. Under Layers, right-click the lisbon_portugal_osm_line layer and click Open Attribute Table.
 2. In the table, the columns across the top represent the most common keys. The rows are individual features in the OSM database referenced by their OSM identification number. As you look through the attribute values, notice that most of the them are `NULL`, indicating that the tag has not been populated.
 
-  ![osm2pgsql attribute table](./images/osm2pgsql_attribute_table.png)
+    ![osm2pgsql attribute table](./images/osm2pgsql_attribute_table.png)
 
 3. Scroll the table to the right to see the highways field and scroll down to see the values in that field.
 
@@ -87,7 +87,9 @@ As you looked through the table, you may have noticed a few features with a valu
 3. Under Operators, click the `equals` button.
 4. Under Values, click All to get a listing of the available values for the highways field.
 5. Double-click `motorway` to add it to the expression. Your expression should read: ``"highway" = 'motorway'``.
-  ![Query for motorways](./images/query_builder.png)
+
+    ![Query for motorways](./images/query_builder.png)
+
 6. Click the Test button to verify the syntax of your query. You should receive a message indicating that over 1,000 rows were returned. If not, make sure your text matches the text in the image.
 7. Click OK.
 
@@ -106,7 +108,7 @@ Because motorways are major roads, they should be displayed with a thicker line.
 3. Find the Motorway symbol in the list of styles and click it.
 4. Click OK to apply the symbol.
 
-  ![Overlapping motorway symbols](./images/overlapping_lines.png)
+    ![Overlapping motorway symbols](./images/overlapping_lines.png)
 
 Because each line feature is being rendered individually, the symbols overlap. Instead, the lines should be drawn as one, continuous feature. You can use a technique called symbol level drawing to merge symbol boundaries.
 
@@ -115,7 +117,7 @@ Because each line feature is being rendered individually, the symbols overlap. I
 7. Check Enable symbol levels.
 8. Click OK on all dialog boxes.
 
-  ![Merged line symbols](./images/symbol_level_lines.png)
+    ![Merged line symbols](./images/symbol_level_lines.png)
 
 Note that there are other cartographic functions on the Styles tab to improve the appearance of the map, including transparency. You can experiment with these on your own.
 
@@ -142,7 +144,8 @@ The features in the places layer are drawn with one symbol, but you can use the 
 6. If there are any symbols without values or legend entries, highlight them in the list and click Delete.
 7. To make the city symbol larger and more prominent, right-click it in the list and click Change size. Set the size to 5.
 
-  ![Places drawn as categories](./images/symbol_categories.png)
+    ![Places drawn as categories](./images/symbol_categories.png)
+
 8. You can experiment with the symbol colors and sizes to make the different points appear the way you want.
 9. Click OK when you are done to return to the map and see your changes.
 10. Optionally, save your project when you are done.


### PR DESCRIPTION
Whooo, different flavors of Markdown....

Handy reference for just how ridiculous the universe is: http://johnmacfarlane.net/babelmark2/?text=1.+list%0A2.+second%0A++!%5Bimage%5D(image.png)%0A%0A3.+third%0A%0A

I did some testing, and here's how I *think* are some simple rules that keeps MkDocs and GitHub happy:

- All images should have a blank line before and after it.
- If it is not part of a list, do *not* indent it.
- If it is part of a list, indent *exactly* four spaces.

That's it -- if we lose a blank line here or there, or the spacing is off, it might break one or the other, or it might not matter at all, but I wanted to avoid complicating the rules as much as possible. Even then, due to the ambiguous nature Markdown syntax, we might *still* run into a weird issue, so... but I hope this is clear enough for now.